### PR TITLE
Include dependencies in external interface

### DIFF
--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -33,6 +33,8 @@ Contains the freeRTOS task and all necessary support
 #define WIFI_MANAGER_H_INCLUDED
 
 #include <stdbool.h>
+#include "esp_wifi_types.h"
+#include "esp_netif.h"
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
According to original author:

> I noticed that including wifi_manager.h fails if these includes are not (implicitly) in the code. I propose to add them to allow easy inclusion.

See https://github.com/tonyp7/esp32-wifi-manager/pull/125