### PR TITLE
Add bootloader_support component for IDF>=4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 if(IDF_VERSION_MAJOR GREATER_EQUAL 4)
     idf_component_register(SRC_DIRS src
-        REQUIRES log nvs_flash mdns wpa_supplicant lwip esp_http_server esp_wifi
+        REQUIRES log nvs_flash mdns wpa_supplicant lwip esp_http_server esp_wifi bootloader_support
         INCLUDE_DIRS src
         EMBED_FILES src/style.css src/code.js src/index.html)
 else()


### PR DESCRIPTION
`<bootloader_random.h>` cannot be found (nor its APIs used) without `bootloader_support` component.